### PR TITLE
Add typing to the render props passed as a child

### DIFF
--- a/src/_tests/context.Spec.tsx
+++ b/src/_tests/context.Spec.tsx
@@ -69,7 +69,7 @@ describe("context", () => {
       );
       render(
         <ctx.Provider value={2}>
-          <ctx.Consumer>{(value: string) => `result: '${value}'`}</ctx.Consumer>
+          <ctx.Consumer>{value => `result: '${value}'`}</ctx.Consumer>
         </ctx.Provider>
       );
       expect(html(scratch)).toEqual("result: '2'");
@@ -77,7 +77,7 @@ describe("context", () => {
       // rerender
       render(
         <ctx.Provider value={3}>
-          <ctx.Consumer>{(value: string) => `result: '${value}'`}</ctx.Consumer>
+          <ctx.Consumer>{value => `result: '${value}'`}</ctx.Consumer>
         </ctx.Provider>
       );
 
@@ -91,7 +91,7 @@ describe("context", () => {
       render(
         <ctx.Provider value={2}>
           <div />
-          <ctx.Consumer>{(value: string) => `result: '${value}'`}</ctx.Consumer>
+          <ctx.Consumer>{value => `result: '${value}'`}</ctx.Consumer>
         </ctx.Provider>
       );
       expect(html(scratch)).toEqual("<span><div></div>result: '2'</span>");
@@ -222,6 +222,7 @@ describe("context", () => {
       const ctx = createContext("The Default Context");
       const warn = sandbox.stub(console, "warn");
 
+      // @ts-ignore
       render(<ctx.Consumer>Nothing</ctx.Consumer>);
 
       sinon.assert.calledWith(
@@ -234,6 +235,7 @@ describe("context", () => {
       const ctx = createContext("The Default Context");
       sandbox.stub(console, "warn");
 
+      // @ts-ignore
       render(<ctx.Consumer>Something</ctx.Consumer>);
 
       expect(html(scratch)).toEqual("");
@@ -618,7 +620,7 @@ describe("context", () => {
       function NumberConsumer(props: RenderableProps<any>) {
         return (
           <numContext.Consumer>
-            {(value: string) => (
+            {value => (
               <div className={`num-consumer c${props.id}`}>
                 <span className="value">{value}</span>
                 {props.children}

--- a/src/context.ts
+++ b/src/context.ts
@@ -11,10 +11,9 @@ export interface ProviderProps<T> {
   value: T;
 }
 
-export interface ConsumerProps<T> {
-  render?: (val: T) => any;
+export type ConsumerProps<T> = {
   unstable_observedBits?: number;
-}
+} & ({ render: (val: T) => any } | { children: (val: T) => any });
 
 export type ConsumerState<T> = ProviderProps<T>;
 
@@ -25,7 +24,7 @@ export interface Context<T> {
 
 function getRenderer<T>(props: RenderableProps<ConsumerProps<T>>) {
   const { child } = getOnlyChildAndChildren(props);
-  return child || props.render;
+  return child || ("render" in props && props.render);
 }
 
 const MAX_SIGNED_31_BIT_INT = 1073741823;
@@ -103,7 +102,7 @@ function _createContext<T>(
     }
 
     render() {
-      const { render } = this.props;
+      const render = "render" in this.props && this.props.render;
       const r = getRenderer(this.props);
       if (render && render !== r) {
         console.warn(


### PR DESCRIPTION
Before the change, the value in the render prop passed as a child would have `any` type:

<img width="518" alt="image 2019-01-07 at 10 09 06 am" src="https://user-images.githubusercontent.com/52201/50749370-817d1a80-1264-11e9-857b-b5f416e84377.png">

The change adds the proper type to the value:

<img width="510" alt="image 2019-01-07 at 10 11 30 am" src="https://user-images.githubusercontent.com/52201/50749384-9d80bc00-1264-11e9-99c8-8cb57c7810f3.png">
