### PR TITLE
Make warnings and logging configurable.

### DIFF
--- a/src/_tests/context.Spec.tsx
+++ b/src/_tests/context.Spec.tsx
@@ -42,6 +42,35 @@ describe("context", () => {
   });
 
   describe("createContext", () => {
+    it("accepts an optional default value as first argument", () => {
+      const ctx = createContext("test", undefined, { providerOptional: true });
+      render(
+        <ctx.Consumer>{(value: String) => <p>Hello {value}</p>}</ctx.Consumer>
+      );
+      expect(html(scratch)).toEqual("<p>Hello test</p>");
+    });
+
+    it("accepts an optional bitmask factory as second argument", () => {
+      const bitmaskFactory = sandbox.stub();
+      const ctx = createContext("test", bitmaskFactory, {
+        providerOptional: true
+      });
+      render(
+        <ctx.Consumer>{(value: String) => <p>Hello {value}</p>}</ctx.Consumer>
+      );
+      expect(html(scratch)).toEqual("<p>Hello test</p>");
+      expect(bitmaskFactory.called);
+    });
+
+    it("accepts an optional options object as third argument", () => {
+      const options = { providerOptional: true };
+      const ctx = createContext("test", undefined, options);
+      render(
+        <ctx.Consumer>{(value: String) => <p>Hello {value}</p>}</ctx.Consumer>
+      );
+      expect(html(scratch)).toEqual("<p>Hello test</p>");
+    });
+
     it("creates an object with a Provider", () => {
       const ctx = createContext("");
       expect(ctx).toHaveProperty("Provider");
@@ -145,6 +174,51 @@ describe("context", () => {
         <ctx.Consumer>{(value: string) => `Hi from '${value}'`}</ctx.Consumer>
       );
 
+      sinon.assert.calledWith(warn, "Consumer used without a Provider");
+    });
+
+    it("does not warn if used with a provider", () => {
+      const ctx = createContext("The Default Context");
+      const warn = sandbox.stub(console, "warn");
+      render(
+        <ctx.Provider value="init">
+          <ctx.Consumer>{(value: string) => `Hi from '${value}'`}</ctx.Consumer>
+        </ctx.Provider>
+      );
+      sinon.assert.notCalled(warn);
+    });
+
+    it("does not warn if used without a Provider from a context with `providerOptional` set", () => {
+      const ctx = createContext("The Default Context", undefined, {
+        providerOptional: true
+      });
+      const warn = sandbox.stub(console, "warn");
+      render(
+        <ctx.Consumer>{(value: string) => `Hi from '${value}'`}</ctx.Consumer>
+      );
+      sinon.assert.notCalled(warn);
+    });
+
+    it("does not warn if used with a Provider from a context with `providerOptional` set", () => {
+      const ctx = createContext("The Default Context", undefined, {
+        providerOptional: true
+      });
+      const warn = sandbox.stub(console, "warn");
+      render(
+        <ctx.Provider value="init">
+          <ctx.Consumer>{(value: string) => `Hi from '${value}'`}</ctx.Consumer>
+        </ctx.Provider>
+      );
+      sinon.assert.notCalled(warn);
+    });
+
+    it("warns using the log object given in options when used without a Provider", () => {
+      const warn = sandbox.stub();
+      const options = { log: { warn } };
+      const ctx = createContext("The Default Context", undefined, options);
+      render(
+        <ctx.Consumer>{(value: string) => `Hi from '${value}'`}</ctx.Consumer>
+      );
       sinon.assert.calledWith(warn, "Consumer used without a Provider");
     });
 

--- a/src/context-value-emitter.ts
+++ b/src/context-value-emitter.ts
@@ -2,6 +2,15 @@ export type StateUpdater<T> = (val: T, bitmask: number) => void;
 
 export type BitmaskFactory<T> = (a: T, b: T) => number;
 
+export interface Log {
+  warn(...args: any[]): void;
+}
+
+export interface Options {
+  providerOptional?: Boolean;
+  log?: Log;
+}
+
 export interface ContextValueEmitter<T> {
   register: (updater: StateUpdater<T>) => void;
   unregister: (updater: StateUpdater<T>) => void;
@@ -39,14 +48,21 @@ export function createEmitter<T>(
   };
 }
 
-export const noopEmitter: ContextValueEmitter<any> = {
-  register(_: StateUpdater<any>) {
-    console.warn("Consumer used without a Provider");
-  },
-  unregister(_: StateUpdater<any>) {
-    // do nothing
-  },
-  val(_: any) {
-    //do nothing;
-  }
-};
+export function createDefaultEmitter(
+  options: Options
+): ContextValueEmitter<any> {
+  const emitter: ContextValueEmitter<any> = {
+    register(_: StateUpdater<any>) {
+      if (!options.providerOptional && options.log) {
+        options.log.warn("Consumer used without a Provider");
+      }
+    },
+    unregister(_: StateUpdater<any>) {
+      // do nothing
+    },
+    val(_: any) {
+      //do nothing;
+    }
+  };
+  return emitter;
+}


### PR DESCRIPTION
* Added interface `Log` with method `warn`
* Added interface `Options` with fields:
    * `providerOptional`: `Boolean`
    * `log`: `Log`
* Replaced `noopEmitter` with emitter factory `createDefaultEmitter`
* Added argument of type `Options` to `createDefaultEmitter`
* Added argument of type `Options` to `createContext`
    * Default `providerOptional` option to `false`
    * Default `log` option to `console` if it exists
* `createContext` creates a `defaultEmitter` by calling `createDefaultEmitter` and passing the options to it
* Use the `defaultEmitter` when there is no emitter
* Replace `console.warn` with calls to `log.warn`

Fixes #24 